### PR TITLE
Redesign mobile-first interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,22 @@
     <title>阿瓦隆桌遊 - 多人線上版</title>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&family=Crimson+Text:ital,wght@0,400;0,600;1,400&display=swap');
-        
+
+        :root {
+            --spacing-xs: 8px;
+            --spacing-sm: 12px;
+            --spacing-md: 16px;
+            --spacing-lg: 24px;
+            --spacing-xl: 32px;
+            --radius-sm: 8px;
+            --radius-md: 16px;
+            --radius-lg: 20px;
+            --text-base: 1rem;
+            --text-sm: 0.95rem;
+            --text-lg: 1.15rem;
+            --max-content-width: 420px;
+        }
+
         * {
             margin: 0;
             padding: 0;
@@ -15,7 +30,7 @@
 
         body {
             font-family: 'Crimson Text', serif;
-            background: 
+            background:
                 radial-gradient(circle at 20% 80%, rgba(120, 119, 198, 0.3) 0%, transparent 50%),
                 radial-gradient(circle at 80% 20%, rgba(255, 119, 198, 0.15) 0%, transparent 50%),
                 radial-gradient(circle at 40% 40%, rgba(120, 119, 198, 0.15) 0%, transparent 50%),
@@ -23,9 +38,13 @@
             color: #f4f1e8;
             min-height: 100vh;
             display: flex;
-            justify-content: center;
+            flex-direction: column;
+            justify-content: flex-start;
             align-items: center;
+            padding: var(--spacing-xl) var(--spacing-md) calc(var(--spacing-xl) * 2);
             position: relative;
+            width: 100%;
+            overflow-x: hidden;
         }
 
         body::before {
@@ -42,20 +61,24 @@
         }
 
         .container {
-            max-width: 1200px;
-            width: 90%;
-            padding: 20px;
+            width: 100%;
+            max-width: var(--max-content-width);
+            margin: 0 auto;
+            padding: 0;
             position: relative;
             z-index: 2;
+            display: flex;
+            flex-direction: column;
+            gap: var(--spacing-lg);
         }
 
         .game-title {
             font-family: 'Cinzel', serif;
             text-align: center;
-            font-size: 3.5em;
+            font-size: clamp(2.2rem, 6vw, 3.5rem);
             font-weight: 700;
-            margin-bottom: 30px;
-            text-shadow: 
+            margin-bottom: 0;
+            text-shadow:
                 0 0 10px rgba(212, 175, 55, 0.8),
                 0 0 20px rgba(212, 175, 55, 0.6),
                 0 0 30px rgba(212, 175, 55, 0.4),
@@ -68,37 +91,40 @@
         .game-title::before {
             content: '⚔️';
             position: absolute;
-            left: -60px;
+            left: -45px;
             top: 50%;
             transform: translateY(-50%);
             font-size: 0.8em;
             opacity: 0.8;
+            display: none;
         }
 
         .game-title::after {
             content: '⚔️';
             position: absolute;
-            right: -60px;
+            right: -45px;
             top: 50%;
             transform: translateY(-50%) scaleX(-1);
             font-size: 0.8em;
             opacity: 0.8;
+            display: none;
         }
 
         .screen {
             display: none;
             text-align: center;
-            background: 
+            background:
                 linear-gradient(145deg, rgba(15, 12, 41, 0.95) 0%, rgba(36, 36, 62, 0.9) 100%);
-            padding: 40px;
-            border-radius: 20px;
+            padding: var(--spacing-xl) var(--spacing-lg);
+            border-radius: var(--radius-lg);
             backdrop-filter: blur(15px);
             border: 2px solid rgba(212, 175, 55, 0.3);
-            box-shadow: 
+            box-shadow:
                 0 8px 32px rgba(0, 0, 0, 0.4),
                 inset 0 1px 0 rgba(255, 255, 255, 0.1),
                 0 0 0 1px rgba(212, 175, 55, 0.1);
             position: relative;
+            width: 100%;
         }
 
         .screen::before {
@@ -123,36 +149,34 @@
 
         /* 用戶名輸入畫面 */
         .name-input {
-            margin: 20px 0;
+            margin: var(--spacing-lg) 0;
         }
 
         .name-input input {
-            padding: 15px;
-            font-size: 1.2em;
+            padding: var(--spacing-sm) var(--spacing-md);
+            font-size: var(--text-lg);
             border: none;
-            border-radius: 8px;
-            width: 300px;
-            max-width: 100%;
+            border-radius: var(--radius-sm);
+            width: 100%;
             text-align: center;
         }
 
         /* 房間選擇畫面 */
         .room-options {
             display: flex;
-            justify-content: center;
-            gap: 30px;
-            margin: 30px 0;
-            flex-wrap: wrap;
+            flex-direction: column;
+            gap: var(--spacing-md);
+            margin: var(--spacing-lg) 0;
         }
 
         .room-option {
             background: rgba(255,255,255,0.1);
-            padding: 30px;
-            border-radius: 15px;
+            padding: var(--spacing-lg);
+            border-radius: var(--radius-md);
             border: 2px solid rgba(255,255,255,0.2);
             cursor: pointer;
             transition: all 0.3s ease;
-            min-width: 200px;
+            width: 100%;
         }
 
         .room-option:hover {
@@ -168,17 +192,20 @@
 
         /* 房間輸入 */
         .room-input {
-            margin: 20px 0;
+            margin: var(--spacing-lg) 0;
+            display: flex;
+            flex-direction: column;
+            gap: var(--spacing-sm);
+            width: 100%;
         }
 
         .room-input input {
-            padding: 12px;
-            font-size: 1.1em;
+            padding: var(--spacing-sm) var(--spacing-md);
+            font-size: var(--text-lg);
             border: none;
-            border-radius: 8px;
-            width: 200px;
+            border-radius: var(--radius-sm);
+            width: 100%;
             text-align: center;
-            margin: 0 10px;
         }
 
         /* 等待大廳 */
@@ -203,18 +230,19 @@
 
         .players-list {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 15px;
-            margin: 20px 0;
+            grid-template-columns: 1fr;
+            gap: var(--spacing-sm);
+            margin: var(--spacing-md) 0;
         }
 
         .player-item {
             background: rgba(255,255,255,0.1);
-            padding: 15px;
-            border-radius: 10px;
+            padding: var(--spacing-md);
+            border-radius: var(--radius-sm);
             display: flex;
-            align-items: center;
-            justify-content: space-between;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: var(--spacing-xs);
         }
 
         .player-item.host {
@@ -272,10 +300,10 @@
 
         /* 遊戲界面 */
         .game-board {
-            display: grid;
-            grid-template-columns: 1fr 2fr 1fr;
-            gap: 20px;
-            align-items: start;
+            display: flex;
+            flex-direction: column;
+            gap: var(--spacing-lg);
+            align-items: stretch;
         }
 
         .player-info {
@@ -340,13 +368,14 @@
         .mission-track {
             display: flex;
             justify-content: center;
-            gap: 15px;
-            margin: 20px 0;
+            flex-wrap: wrap;
+            gap: var(--spacing-sm);
+            margin: var(--spacing-lg) 0;
         }
 
         .mission-card {
-            width: 90px;
-            height: 130px;
+            width: clamp(72px, 22vw, 110px);
+            height: clamp(100px, 32vw, 150px);
             background: linear-gradient(145deg, rgba(15, 12, 41, 0.9) 0%, rgba(36, 36, 62, 0.8) 100%);
             border-radius: 12px;
             display: flex;
@@ -358,7 +387,7 @@
             font-family: 'Cinzel', serif;
             font-weight: 500;
             position: relative;
-            box-shadow: 
+            box-shadow:
                 0 4px 8px rgba(0, 0, 0, 0.3),
                 inset 0 1px 0 rgba(255, 255, 255, 0.1);
             transition: all 0.3s ease;
@@ -448,19 +477,20 @@
             background: linear-gradient(145deg, #3a4a6b 0%, #2c3e50 100%);
             color: #f4f1e8;
             border: 2px solid rgba(212, 175, 55, 0.6);
-            padding: 12px 24px;
-            border-radius: 6px;
+            padding: var(--spacing-sm) var(--spacing-lg);
+            border-radius: var(--radius-sm);
             cursor: pointer;
-            font-size: 1em;
+            font-size: var(--text-lg);
             font-weight: 500;
             letter-spacing: 1px;
             text-transform: uppercase;
             transition: all 0.3s ease;
-            margin: 5px;
+            margin: var(--spacing-xs) 0;
             position: relative;
-            box-shadow: 
+            box-shadow:
                 0 4px 8px rgba(0, 0, 0, 0.3),
                 inset 0 1px 0 rgba(255, 255, 255, 0.1);
+            width: 100%;
         }
 
         .btn::before {
@@ -613,12 +643,13 @@
             font-family: 'Crimson Text', serif;
             background: linear-gradient(145deg, rgba(15, 12, 41, 0.8) 0%, rgba(36, 36, 62, 0.6) 100%);
             border: 2px solid rgba(212, 175, 55, 0.4);
-            border-radius: 8px;
-            padding: 12px 16px;
+            border-radius: var(--radius-sm);
+            padding: var(--spacing-sm) var(--spacing-md);
             color: #f4f1e8;
-            font-size: 1.1em;
+            font-size: var(--text-lg);
             transition: all 0.3s ease;
             box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+            width: 100%;
         }
 
         input[type="text"]:focus, input[type="number"]:focus {
@@ -635,74 +666,143 @@
         }
 
         /* 響應式設計 */
-        @media (max-width: 768px) {
-            .game-title {
-                font-size: 2.5em;
+        @media (min-width: 600px) {
+            :root {
+                --max-content-width: 640px;
             }
-            
+
+            body {
+                padding: calc(var(--spacing-xl) * 1.2) var(--spacing-xl) calc(var(--spacing-xl) * 2.2);
+            }
+
+            .container {
+                gap: var(--spacing-xl);
+            }
+
             .game-title::before,
             .game-title::after {
-                display: none;
+                display: block;
             }
-            
+
             .room-options {
-                flex-direction: column;
+                flex-direction: row;
+                flex-wrap: wrap;
+            }
+
+            .room-option {
+                flex: 1 1 calc(50% - var(--spacing-sm));
+            }
+
+            .room-input {
+                flex-direction: row;
                 align-items: center;
             }
-            
+
+            .room-input input {
+                max-width: 200px;
+            }
+
+            .room-input .btn {
+                width: auto;
+            }
+
+            .players-list {
+                grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+                gap: var(--spacing-md);
+            }
+
+            .player-item {
+                flex-direction: row;
+                align-items: center;
+                justify-content: space-between;
+            }
+
+            .btn {
+                width: auto;
+                margin: var(--spacing-xs);
+            }
+
+            .role-selection-container {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+
+            .role-actions {
+                flex-direction: row;
+                align-items: center;
+            }
+
+            .role-actions .btn {
+                max-width: 220px;
+            }
+        }
+
+        @media (min-width: 960px) {
+            :root {
+                --max-content-width: 1100px;
+            }
+
+            .container {
+                max-width: var(--max-content-width);
+            }
+
+            .screen {
+                padding: calc(var(--spacing-xl) * 1.25) calc(var(--spacing-xl) * 1.5);
+            }
+
             .game-board {
-                grid-template-columns: 1fr;
-                gap: 15px;
+                display: grid;
+                grid-template-columns: 1fr 1.5fr 1fr;
+                gap: var(--spacing-xl);
+                align-items: start;
             }
-            
+
             .mission-track {
-                gap: 8px;
+                gap: var(--spacing-md);
             }
-            
-            .mission-card {
-                width: 60px;
-                height: 90px;
-                font-size: 0.8em;
+
+            .spinner {
+                width: 320px;
+                height: 320px;
             }
         }
 
         /* 角色選擇界面 */
         .role-selection-container {
             display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 30px;
-            margin: 30px 0;
+            grid-template-columns: 1fr;
+            gap: var(--spacing-lg);
+            margin: var(--spacing-lg) 0;
         }
 
         .role-category {
             background: rgba(255,255,255,0.1);
-            padding: 20px;
-            border-radius: 10px;
+            padding: var(--spacing-lg);
+            border-radius: var(--radius-sm);
             border: 1px solid rgba(255,255,255,0.2);
         }
 
         .role-category h3 {
             text-align: center;
-            margin-bottom: 20px;
+            margin-bottom: var(--spacing-md);
             font-size: 1.3em;
         }
 
         .role-checkboxes {
             display: flex;
             flex-direction: column;
-            gap: 15px;
+            gap: var(--spacing-sm);
         }
 
         .role-checkbox {
             background: rgba(255,255,255,0.05);
-            padding: 15px;
-            border-radius: 8px;
+            padding: var(--spacing-md);
+            border-radius: var(--radius-sm);
             border: 1px solid rgba(255,255,255,0.1);
             cursor: pointer;
             transition: all 0.3s ease;
             display: flex;
             align-items: flex-start;
-            gap: 10px;
+            gap: var(--spacing-sm);
         }
 
         .role-checkbox:hover {
@@ -737,8 +837,8 @@
 
         .role-counter {
             background: rgba(255,255,255,0.05);
-            padding: 15px;
-            border-radius: 8px;
+            padding: var(--spacing-md);
+            border-radius: var(--radius-sm);
             border: 1px solid rgba(255,255,255,0.1);
         }
 
@@ -746,33 +846,33 @@
             font-size: 1.1em;
             font-weight: bold;
             display: block;
-            margin-bottom: 10px;
+            margin-bottom: var(--spacing-sm);
         }
 
         .counter-controls {
             display: flex;
             align-items: center;
             justify-content: center;
-            gap: 15px;
-            margin: 10px 0;
+            gap: var(--spacing-md);
+            margin: var(--spacing-sm) 0;
         }
 
         .counter-btn {
             background: #2196F3;
             color: white;
             border: none;
-            padding: 8px 15px;
-            border-radius: 5px;
+            padding: var(--spacing-xs) var(--spacing-md);
+            border-radius: var(--radius-sm);
             cursor: pointer;
-            font-size: 1.2em;
+            font-size: 1.1em;
             font-weight: bold;
-            min-width: 35px;
+            min-width: 38px;
             transition: all 0.3s ease;
         }
 
         .counter-btn:hover {
             background: #1976D2;
-            transform: scale(1.1);
+            transform: scale(1.05);
         }
 
         .counter-btn:disabled {
@@ -811,14 +911,15 @@
 
         .role-actions {
             display: flex;
-            justify-content: space-between;
-            gap: 20px;
-            margin-top: 30px;
+            flex-direction: column;
+            justify-content: center;
+            gap: var(--spacing-sm);
+            margin-top: var(--spacing-lg);
         }
 
         .role-actions .btn {
             flex: 1;
-            max-width: 200px;
+            max-width: none;
         }
 
         /* 隱藏類 */
@@ -936,8 +1037,8 @@
 
         .spinner {
             position: relative;
-            width: 300px;
-            height: 300px;
+            width: min(260px, 80vw);
+            height: min(260px, 80vw);
             border: 5px solid #ffd700;
             border-radius: 50%;
             background: #2a5298;
@@ -991,7 +1092,8 @@
             grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
             gap: 10px;
             margin: 20px 0;
-            max-width: 300px;
+            width: 100%;
+            max-width: 340px;
             margin-left: auto;
             margin-right: auto;
         }
@@ -1145,26 +1247,6 @@
             opacity: 0.9;
         }
 
-        /* 響應式設計 - 角色選擇 */
-        @media (max-width: 768px) {
-            .role-selection-container {
-                grid-template-columns: 1fr;
-                gap: 20px;
-            }
-            
-            .role-actions {
-                flex-direction: column;
-                align-items: center;
-            }
-            
-            .role-actions .btn {
-                max-width: none;
-            }
-            
-            .lake-lady-players {
-                grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-            }
-        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- introduce spacing variables and mobile-first layout styling to improve the experience on phones
- update room, lobby, game board, and role selection sections to stack cleanly with responsive breakpoints for larger screens
- resize controls and spinner elements so touch targets and mission cards remain usable on small displays

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68daae6548788327abc86dd8eb1a497e